### PR TITLE
require three module instead of global object

### DIFF
--- a/partykals/_three.js
+++ b/partykals/_three.js
@@ -1,3 +1,3 @@
 // This file is just a wrapper to get THREE base module.
 // If its not in your global space, edit this file accordingly.
-module.exports = window.THREE;
+module.exports = require('three');


### PR DESCRIPTION
Thank you for the project!

I would like to use partykals in my project, but I am not using global scope to load three.js modules, instead I am relying on JSM (https://threejs.org/docs/#manual/en/introduction/Import-via-modules). `_three.js` file relies on global THREE object. I think it would be a good idea to import a module and maybe create some kind of workaround to allow standalone builds.

Best wishes

PS. I also really like your other JS-related game projects. I will check them out soon. :) 