### PR TITLE
add 'dispose' method to the system

### DIFF
--- a/partykals/particles_system.js
+++ b/partykals/particles_system.js
@@ -246,6 +246,14 @@ class ParticlesSystem
     }
 
     /**
+     * Dispose the entire system.
+     */
+    dispose()
+    {
+        this.particlesGeometry.dispose();
+    }
+
+    /**
      * Did finish emitting?
      */
     get finished()


### PR DESCRIPTION
It would be good to have a `dispose` method to cleanly remove the system. I am working on a browser game currently and I need to dispose entire scene and then mount another one in the canvas. Disposing is necessary to prevent memory leaks.

I am not sure if the geometry is the only disposable object in the system. I would really appreciate that if you could improve this method. :)